### PR TITLE
Add Margaret Watkins' preferred name and people directory info

### DIFF
--- a/people/margaret.watkins.txt
+++ b/people/margaret.watkins.txt
@@ -1,0 +1,1 @@
+Margaret Watkins  VSCode  Scala

--- a/teamList.txt
+++ b/teamList.txt
@@ -35,7 +35,7 @@ X	Kostandinos Sergakis
 X	Mark Snyder
 Charles Toller (Charles)
 X	Brady Trappett
-X	Margaret Watkins
+Margaret Watkins (Margaret)
 Dan Watson (Dan)
 X	Joshua Webster
 X	Christian Winwood


### PR DESCRIPTION
Margaret Watkins is a class member and should be included in the people directory and have her preferred name in the class list.